### PR TITLE
Avoid hitting test on invalid positions

### DIFF
--- a/Assets/Scripts/Core/Stage.cs
+++ b/Assets/Scripts/Core/Stage.cs
@@ -917,7 +917,9 @@ namespace FairyGUI
 #endif
                 pos.y = Screen.height - pos.y;
                 TouchInfo touch = _touches[0];
-                if (pos.x < 0 || pos.y < 0) // outside of the window
+                if (float.IsNaN(pos.x) || float.IsNaN(pos.y) || float.IsInfinity(pos.x) || float.IsInfinity(pos.y)) //not a valid position
+                    _touchTarget = this;
+                else if (pos.x < 0 || pos.y < 0) // outside of the window
                     _touchTarget = this;
                 else
                     _touchTarget = HitTest(pos, true);


### PR DESCRIPTION
Error messages like this will fill up all the console, when starting an example scene

Screen position out of view frustum (screen pos inf, -inf, 0.000000) (Camera rect 0 0 1536 2048)